### PR TITLE
Fix: squid:S106, Replace the usage of System.out by a logger

### DIFF
--- a/src/test/java/com/github/drapostolos/rdp4j/ListenerImpl.java
+++ b/src/test/java/com/github/drapostolos/rdp4j/ListenerImpl.java
@@ -1,45 +1,50 @@
 package com.github.drapostolos.rdp4j;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class ListenerImpl extends AbstractRdp4jListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ListenerImpl.class);
 
     @Override
     public void afterPollingCycle(AfterPollingCycleEvent event) {
-        System.out.println(event);
+        LOG.info(event.toString());
     }
 
     @Override
     public void beforePollingCycle(BeforePollingCycleEvent event) {
-        System.out.println(event);
+        LOG.info(event.toString());
     }
 
     @Override
     public void fileAdded(FileAddedEvent event) {
-        System.out.println(event);
+        LOG.info(event.toString());
     }
 
     @Override
     public void fileModified(FileModifiedEvent event) {
-        System.out.println(event);
+        LOG.info(event.toString());
     }
 
     @Override
     public void afterStop(AfterStopEvent event) {
-        System.out.println(event);
+        LOG.info(event.toString());
     }
 
     @Override
     public void beforeStart(BeforeStartEvent event) {
-        System.out.println(event);
+        LOG.info(event.toString());
     }
 
     @Override
     public void fileRemoved(FileRemovedEvent event) {
-        System.out.println(event);
+        LOG.info(event.toString());
     }
 
     @Override
     public void initialContent(InitialContentEvent event) {
-        System.out.println(event);
+        LOG.info(event.toString());
     }
 
 }

--- a/src/test/java/com/github/drapostolos/rdp4j/PollCycleCounter.java
+++ b/src/test/java/com/github/drapostolos/rdp4j/PollCycleCounter.java
@@ -1,9 +1,14 @@
 package com.github.drapostolos.rdp4j;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 
 public class PollCycleCounter extends AbstractRdp4jListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PollCycleCounter.class);
 
     private int cycleCounter = 0;
     private int numOfcyclesBeforeStop = Integer.MAX_VALUE;
@@ -96,7 +101,7 @@ public class PollCycleCounter extends AbstractRdp4jListener {
 
     private void logEventIfDebugEnabled(Event event) {
         if (debugEnabled) {
-            System.out.println("# " + event.getClass().getSimpleName() + "; ThreadId: "
+            LOG.debug("# " + event.getClass().getSimpleName() + "; ThreadId: "
                     + Thread.currentThread().getId());
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S106 - “Standard outputs should not be used directly to log anything”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S106

 Please let me know if you have any questions.
Ayman Elkfrawy.