### PR TITLE
Add basic API to set/get start/end state of a DirectoryPoller.

### DIFF
--- a/src/main/java/com/github/drapostolos/rdp4j/AfterStopEvent.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/AfterStopEvent.java
@@ -1,5 +1,15 @@
 package com.github.drapostolos.rdp4j;
 
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.github.drapostolos.rdp4j.spi.FileElement;
+import com.github.drapostolos.rdp4j.spi.PolledDirectory;
+
 /**
  * An event that represents the stopping of the {@link DirectoryPoller}, as
  * triggered by this method: {@link DirectoryPoller#stop()}.
@@ -7,9 +17,44 @@ package com.github.drapostolos.rdp4j;
  * @see <a href="https://github.com/drapostolos/rdp4j/wiki/User-Guide">User-Guide</a>
  */
 public final class AfterStopEvent extends EventExposingDirectoryPoller {
+    private Map<PolledDirectory, Set<FileElement>> currentFiles;
+    private Map<PolledDirectory, Set<CachedFileElement>> currentCachedFiles;
 
-    AfterStopEvent(DirectoryPoller directoryPoller) {
+	AfterStopEvent(DirectoryPoller directoryPoller, Set<Poller> pollers) {
         super(directoryPoller);
+        currentCachedFiles = pollers.stream().collect(toMap(
+        		p -> p.directory, 
+        		p -> new HashSet<>(cachedFiles(p))));
+        currentFiles = pollers.stream().collect(toMap(
+        		p -> p.directory, 
+        		p -> new HashSet<>(currentFiles(p))));
     }
 
+	private Set<FileElement> currentFiles(Poller p) {
+		return p.currentListedFiles.values().stream()
+		.map(f -> f.getFileElement())
+		.collect(toSet());
+	}
+
+	private Set<CachedFileElement> cachedFiles(Poller p) {
+		return p.currentListedFiles.values().stream()
+		.map(f -> f.getCachedFileElement())
+		.collect(toSet());
+	}
+
+	/**
+     * @return A Map with all {@link FileElement}s listed by each {@link PolledDirectory}
+     * in the last poll.
+	 */
+	public Map<PolledDirectory, Set<FileElement>> getFileElements() {
+		return currentFiles;
+	}
+	
+	/**
+     * @return A Map with all {@link CachedFileElement}s listed by each {@link PolledDirectory}
+     * in the last poll.
+	 */
+	public Map<PolledDirectory, Set<CachedFileElement>> getCachedFileElements() {
+		return currentCachedFiles;
+	}
 }

--- a/src/main/java/com/github/drapostolos/rdp4j/BeforeStartEvent.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/BeforeStartEvent.java
@@ -1,5 +1,9 @@
 package com.github.drapostolos.rdp4j;
 
+import java.util.Set;
+
+import com.github.drapostolos.rdp4j.spi.PolledDirectory;
+
 /**
  * An event that represents the start the {@link DirectoryPoller}, as
  * triggered by this method: {@link DirectoryPollerBuilder#start()}.
@@ -7,5 +11,30 @@ package com.github.drapostolos.rdp4j;
  * @see <a href="https://github.com/drapostolos/rdp4j/wiki/User-Guide">User-Guide</a>
  */
 public final class BeforeStartEvent implements Event {
+	private DirectoryPollerBuilder builder;
+
+	BeforeStartEvent(DirectoryPollerBuilder builder) {
+		this.builder = builder;
+	}
+
+	/**
+	 * @see DirectoryPollerBuilder#addPolledDirectory(PolledDirectory, CachedFileElement...)
+	 * 
+	 * @param directory
+	 * @param previousState
+	 */
+	public void addPolledDirectory(PolledDirectory directory, CachedFileElement... previousState) {
+		builder.addPolledDirectory(directory, previousState);
+	}
+
+	/**
+	 * @see DirectoryPollerBuilder#addPolledDirectory(PolledDirectory, Set)
+	 * 
+	 * @param directory
+	 * @param previousState
+	 */
+	public void addPolledDirectory(PolledDirectory directory, Set<CachedFileElement> previousState) {
+		builder.addPolledDirectory(directory, previousState);
+	}
 
 }

--- a/src/main/java/com/github/drapostolos/rdp4j/CachedFileElement.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/CachedFileElement.java
@@ -1,22 +1,68 @@
 package com.github.drapostolos.rdp4j;
 
+import java.io.IOException;
+import java.io.Serializable;
+
 import com.github.drapostolos.rdp4j.spi.FileElement;
 
 /**
- * This class exists solely for the purpose of holding cached
- * attributes of {@link FileElement} instance. To avoid unnecessary
+ * This class exists solely for the purpose of holding serializable cached
+ * attributes of a {@link FileElement} instance. To avoid unnecessary
  * calls to a {@link FileElement} instance (in case it does live look ups).
  */
-class CachedFileElement implements FileElement {
-
-    final FileElement fileElement;
-    private final String name;
+public final class CachedFileElement implements FileElement, Serializable {
+	private static final long serialVersionUID = 1L;
+	private final String name;
     private final long lastModified;
+    private final boolean isDirectory;
+    
+	static CachedFileElement of(FileElement fileElement) throws IOException {
+		return of(fileElement.getName(), fileElement.lastModified(), fileElement.isDirectory());
+	}
 
-    CachedFileElement(FileElement fileElement, String name, long lastModified) {
-        this.fileElement = fileElement;
+	/**
+	 * Returns a {@link FileElement} implementation for a file that holds 
+	 * cached data, i.e. a snapshot of a files state at some point in time. 
+	 * No live lookup is done.
+	 * 
+	 * @param name of the file.
+	 * @param timeModified the time this file was modified.
+	 * @return a {@link FileElement} with cached values.
+	 */
+	public static CachedFileElement ofFile(String name, long timeModified) {
+		return of(name, timeModified, false);
+	}
+
+	/**
+	 * Returns a {@link FileElement} implementation for a directory that holds 
+	 * cached data, i.e. a snapshot of a files state at some point in time. 
+	 * No live lookup is done.
+	 * 
+	 * @param name of the file.
+	 * @param timeModified the time this directory was modified.
+	 * @return a {@link FileElement} with cached values.
+	 */
+	public static CachedFileElement ofDir(String name, long timeModified) {
+		return of(name, timeModified, true);
+	}
+
+	/**
+	 * Returns a {@link FileElement} implementation that holds cached data, i.e. a snapshot
+	 * of a files state at some point in time. No live lookup is done.
+	 * 
+	 * @param name of the file.
+	 * @param timeModified the time this file was modified.
+	 * @param isDirectory true if this is a directory, otherwise false.
+	 * @return a {@link FileElement} with cached values.
+	 */
+	public static CachedFileElement of(String name, long timeModified, boolean isDirectory) {
+		return new CachedFileElement(name, timeModified, isDirectory);
+	}
+
+	private CachedFileElement(String name, long lastModified, boolean isDirectory) {
         this.name = name;
         this.lastModified = lastModified;
+		this.isDirectory = isDirectory;
     }
 
     @Override
@@ -26,12 +72,46 @@ class CachedFileElement implements FileElement {
 
     @Override
     public boolean isDirectory() {
-        return fileElement.isDirectory();
+        return isDirectory;
     }
 
     @Override
     public String getName() {
         return name;
     }
+    
+	@Override
+	public String toString() {
+		return "CachedFileElement [name=" + name + ", lastModified=" + lastModified + ", isDirectory=" + isDirectory
+				+ "]";
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + (int) (lastModified ^ (lastModified >>> 32));
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		CachedFileElement other = (CachedFileElement) obj;
+		if (lastModified != other.lastModified)
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		return true;
+	}
 
 }

--- a/src/main/java/com/github/drapostolos/rdp4j/DirectoryPollerFuture.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/DirectoryPollerFuture.java
@@ -1,5 +1,6 @@
 package com.github.drapostolos.rdp4j;
 
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 /**
@@ -25,14 +26,19 @@ public final class DirectoryPollerFuture {
      * 
      * @return a started {@link DirectoryPoller} instance.
      */
-    public DirectoryPoller get() {
-        try {
-            return future.get();
-        } catch (Exception e) {
-            String message = "get() method threw exception!";
-            throw new UnsupportedOperationException(message, e);
-        }
-    }
+	public DirectoryPoller get() {
+		try {
+			return future.get();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException(e);
+		} catch (ExecutionException e) {
+			if (e.getCause() instanceof RuntimeException) {
+				throw (RuntimeException) e.getCause();
+			}
+			throw new IllegalStateException(e);
+		}
+	}
 
     /**
      * @return true if {@link DirectoryPoller} has started, otherwise false.

--- a/src/main/java/com/github/drapostolos/rdp4j/EventExposingFileElement.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/EventExposingFileElement.java
@@ -4,18 +4,28 @@ import com.github.drapostolos.rdp4j.spi.FileElement;
 import com.github.drapostolos.rdp4j.spi.PolledDirectory;
 
 abstract class EventExposingFileElement extends EventExposingPolledDirectory {
+    private final FileElementAndCache cache;
 
-    private final FileElement file;
-
-    EventExposingFileElement(DirectoryPoller directoryPoller, PolledDirectory directory, FileElement file) {
+    EventExposingFileElement(DirectoryPoller directoryPoller, PolledDirectory directory, FileElementAndCache cache) {
         super(directoryPoller, directory);
-        this.file = file;
+        this.cache = cache;
     }
 
     /**
      * @return the {@link FileElement} triggering this event.
      */
     public FileElement getFileElement() {
-        return file;
+        return cache.getFileElement();
+    }
+
+    /**
+     * @return cached version of the {@link FileElement} that triggering this event.
+     * 
+     * A cached {@link FileElement} will always return the same values, for example {@link FileElement#lastModified()}
+     * will return the value used by the {@link DirectoryPoller} during this poll cycle. Any modifications to
+     * the real {@link FileElement} will not be reflected in {@link CachedFileElement}. 
+     */
+    public CachedFileElement getCachedFileElement() {
+        return cache.getCachedFileElement();
     }
 }

--- a/src/main/java/com/github/drapostolos/rdp4j/FileAddedEvent.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/FileAddedEvent.java
@@ -1,6 +1,5 @@
 package com.github.drapostolos.rdp4j;
 
-import com.github.drapostolos.rdp4j.spi.FileElement;
 import com.github.drapostolos.rdp4j.spi.PolledDirectory;
 
 /**
@@ -10,7 +9,7 @@ import com.github.drapostolos.rdp4j.spi.PolledDirectory;
  */
 public final class FileAddedEvent extends EventExposingFileElement {
 
-    FileAddedEvent(DirectoryPoller directoryPoller, PolledDirectory directory, FileElement file) {
+    FileAddedEvent(DirectoryPoller directoryPoller, PolledDirectory directory, FileElementAndCache file) {
         super(directoryPoller, directory, file);
     }
 

--- a/src/main/java/com/github/drapostolos/rdp4j/FileElementAndCache.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/FileElementAndCache.java
@@ -1,0 +1,37 @@
+package com.github.drapostolos.rdp4j;
+
+import com.github.drapostolos.rdp4j.spi.FileElement;
+
+final class FileElementAndCache {
+	private final FileElement file;
+	private final CachedFileElement cache;
+	
+
+	FileElementAndCache(FileElement file, CachedFileElement cache) {
+		this.file = file;
+		this.cache = cache;
+		
+	}
+	
+	FileElement getFileElement() {
+		return file;
+	}
+
+	CachedFileElement getCachedFileElement() {
+		return cache;
+	}
+
+	public long lastModified() {
+		return cache.lastModified();
+	}
+
+	public String getName() {
+		return cache.getName();
+	}
+	
+	@Override
+	public String toString() {
+		return String.format("FileElementAndCache [%s;%s;%s]", 
+				cache.getName(), cache.lastModified(), cache.isDirectory());
+	}
+}

--- a/src/main/java/com/github/drapostolos/rdp4j/FileFilter.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/FileFilter.java
@@ -9,6 +9,7 @@ import com.github.drapostolos.rdp4j.spi.PolledDirectory;
  * 
  * @see <a href="https://github.com/drapostolos/rdp4j/wiki/User-Guide">User-Guide</a>
  */
+@FunctionalInterface
 public interface FileFilter {
 
     /**

--- a/src/main/java/com/github/drapostolos/rdp4j/FileModifiedEvent.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/FileModifiedEvent.java
@@ -1,6 +1,5 @@
 package com.github.drapostolos.rdp4j;
 
-import com.github.drapostolos.rdp4j.spi.FileElement;
 import com.github.drapostolos.rdp4j.spi.PolledDirectory;
 
 /**
@@ -10,7 +9,7 @@ import com.github.drapostolos.rdp4j.spi.PolledDirectory;
  */
 public final class FileModifiedEvent extends EventExposingFileElement {
 
-    FileModifiedEvent(DirectoryPoller directoryPoller, PolledDirectory directory, FileElement file) {
+    FileModifiedEvent(DirectoryPoller directoryPoller, PolledDirectory directory, FileElementAndCache file) {
         super(directoryPoller, directory, file);
     }
 

--- a/src/main/java/com/github/drapostolos/rdp4j/FileRemovedEvent.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/FileRemovedEvent.java
@@ -1,6 +1,5 @@
 package com.github.drapostolos.rdp4j;
 
-import com.github.drapostolos.rdp4j.spi.FileElement;
 import com.github.drapostolos.rdp4j.spi.PolledDirectory;
 
 /**
@@ -10,7 +9,7 @@ import com.github.drapostolos.rdp4j.spi.PolledDirectory;
  */
 public final class FileRemovedEvent extends EventExposingFileElement {
 
-    FileRemovedEvent(DirectoryPoller directoryPoller, PolledDirectory directory, FileElement file) {
+    FileRemovedEvent(DirectoryPoller directoryPoller, PolledDirectory directory, FileElementAndCache file) {
         super(directoryPoller, directory, file);
     }
 

--- a/src/main/java/com/github/drapostolos/rdp4j/HashMapComparer.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/HashMapComparer.java
@@ -5,31 +5,31 @@ import java.util.Map;
 
 final class HashMapComparer<K, V> {
 
-    private Map<K, V> m1, m2, added, removed;
+    private Map<K, V> oldMap, newMap, added, removed;
 
-    HashMapComparer(Map<K, V> m1, Map<K, V> m2) {
-        this.m1 = m1;
-        this.m2 = m2;
-        setAdded();
-        setRemoved();
+    HashMapComparer(Map<K, V> oldMap, Map<K, V> newMap) {
+        this.oldMap = oldMap;
+        this.newMap = newMap;
+        initAdded();
+        initRemoved();
     }
 
-    private void setAdded() {
-        added = new HashMap<K, V>(m2);
-        for (K key : m1.keySet()) {
+    private void initAdded() {
+        added = new HashMap<K, V>(newMap);
+        for (K key : oldMap.keySet()) {
             added.remove(key);
         }
     }
 
-    private void setRemoved() {
-        removed = new HashMap<K, V>(m1);
-        for (K key : m2.keySet()) {
+    private void initRemoved() {
+        removed = new HashMap<K, V>(oldMap);
+        for (K key : newMap.keySet()) {
             removed.remove(key);
         }
     }
 
     /**
-     * Returns the element that are in m2, but not in m1.
+     * Returns the element that are in newMap, but not in oldMap.
      * 
      * @return
      */
@@ -38,7 +38,7 @@ final class HashMapComparer<K, V> {
     }
 
     /**
-     * Returns the element that are in m1, but not in m2.
+     * Returns the element that are in oldMap, but not in newMap.
      * 
      * @return
      */
@@ -50,7 +50,7 @@ final class HashMapComparer<K, V> {
      * @return
      */
     boolean hasDiff() {
-        return !m1.equals(m2);
+        return !oldMap.equals(newMap);
     }
 
     @Override

--- a/src/main/java/com/github/drapostolos/rdp4j/InitialContentEvent.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/InitialContentEvent.java
@@ -1,8 +1,8 @@
 package com.github.drapostolos.rdp4j;
 
-import static com.github.drapostolos.rdp4j.Util.copyValuesToFileElementSet;
+import static java.util.stream.Collectors.toSet;
 
-import java.util.Map;
+import java.util.Collection;
 import java.util.Set;
 
 import com.github.drapostolos.rdp4j.spi.FileElement;
@@ -17,22 +17,43 @@ import com.github.drapostolos.rdp4j.spi.PolledDirectory;
  * @see <a href="https://github.com/drapostolos/rdp4j/wiki/User-Guide">User-Guide</a>
  */
 public final class InitialContentEvent extends EventExposingPolledDirectory {
+    private final Set<FileElement> fileElements;
+    private final Set<CachedFileElement> cachedFileElements;
 
-    private final Set<FileElement> copy;
-
-    InitialContentEvent(DirectoryPoller dp, PolledDirectory directory, Map<String, CachedFileElement> initialFiles) {
+    InitialContentEvent(DirectoryPoller dp, PolledDirectory directory, Collection<FileElementAndCache> files) {
         super(dp, directory);
-        copy = copyValuesToFileElementSet(initialFiles);
+        fileElements = files.stream()
+        		.map(FileElementAndCache::getFileElement)
+        		.collect(toSet());
+        cachedFileElements = files.stream()
+        		.map(FileElementAndCache::getCachedFileElement)
+        		.collect(toSet());
+    }
+    
+	/**
+	 * Use {@link #getFileElements()} method instead.
+	 * 
+     * @return a set of all {@link FileElement}s contained in this {@link PolledDirectory}
+     *         at startup.
+     */
+    @Deprecated
+    public Set<FileElement> getFiles() {
+        return getFileElements();
+    }
+
+	/**
+     * @return a set of all {@link FileElement}s contained in this {@link PolledDirectory}
+     *         at startup.
+     */
+    public Set<FileElement> getFileElements() {
+        return fileElements;
     }
 
     /**
-     * @return a set of all {@link FileElement}s contained in a {@link PolledDirectory}
+     * @return a set of all {@link CachedFileElement}s contained in this {@link PolledDirectory}
      *         at startup.
      */
-    // TODO return the CachedFileElement instead? fix this when fixing :
-    // https://github.com/drapostolos/rdp4j/issues/2
-    public Set<FileElement> getFiles() {
-        return copy;
+    public Set<CachedFileElement> getCachedFileElements() {
+        return cachedFileElements;
     }
-
 }

--- a/src/main/java/com/github/drapostolos/rdp4j/JavaIoFileAdapter.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/JavaIoFileAdapter.java
@@ -11,7 +11,7 @@ import com.github.drapostolos.rdp4j.spi.PolledDirectory;
 /**
  * An adapter for java's {@link File} class, that enables monitoring a directory
  * on the local file system. The main purpose of this adapter is to provide
- * an example how to use an Abstract Directory Poller.
+ * an example how to use a Directory Poller.
  * <p>
  * Using this to listen to events on your local file system is discouraged, use the 
  * Java7 WatchService functionality instead. For Java6 see other options

--- a/src/main/java/com/github/drapostolos/rdp4j/ListenerNotifier.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/ListenerNotifier.java
@@ -55,6 +55,7 @@ class ListenerNotifier {
         try {
             notifyListeners(DirectoryPollerListener.class, listener -> listener.afterStop(event));
         } catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
             // ignore
         }
     }
@@ -63,6 +64,7 @@ class ListenerNotifier {
         try {
             notifyListeners(DirectoryPollerListener.class, listener -> listener.beforeStart(event));
         } catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
             // ignore
         }
     }
@@ -84,12 +86,7 @@ class ListenerNotifier {
             throws InterruptedException {
         for (Rdp4jListener listener : listeners) {
             if (isInstanceOf(listener, listenerType)) {
-                /*
-                 * This cast is correct, since we check if listener
-                 * is instance of listenerType.
-                 */
-                @SuppressWarnings("unchecked")
-                T listener2 = (T) listener;
+                T listener2 = listenerType.cast(listener);
                 try {
                     notifier.notify(listener2);
                 } catch (InterruptedException e) {

--- a/src/main/java/com/github/drapostolos/rdp4j/SerializeToFilePersister.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/SerializeToFilePersister.java
@@ -1,0 +1,65 @@
+package com.github.drapostolos.rdp4j;
+
+import static java.util.stream.Collectors.toMap;
+
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Function;
+
+import com.github.drapostolos.rdp4j.spi.Persister;
+import com.github.drapostolos.rdp4j.spi.PolledDirectory;
+
+class SerializeToFilePersister implements Persister {
+	private Path storage;
+	private Function<String, PolledDirectory> stringToDir;
+	private Function<PolledDirectory, String> dirToString;
+
+	SerializeToFilePersister(Path file, Function<String, PolledDirectory> stringToDir,
+			Function<PolledDirectory, String> dirToString) {
+				this.storage = file;
+				this.stringToDir = stringToDir;
+				this.dirToString = dirToString;
+	}
+
+	@Override
+	public boolean containsData() {
+		return Files.exists(storage);
+	}
+
+	@Override
+	public Map<PolledDirectory, Set<CachedFileElement>> readData() {
+		try (	FileInputStream fis = new FileInputStream(storage.toFile());
+				ObjectInputStream ois = new ObjectInputStream(fis);){
+		    @SuppressWarnings("unchecked")
+			Map<String, Set<CachedFileElement>> files = (Map<String, Set<CachedFileElement>>) ois.readObject();
+		    return convertMapKey(files, stringToDir);
+		} catch (Exception e) {
+			throw new IllegalStateException(e);
+		}
+	}
+	
+	private <T, S> Map<T, Set<CachedFileElement>> convertMapKey(
+			Map<S, Set<CachedFileElement>> map, Function<S, T> mapper) {
+		return map.entrySet().stream()
+		.collect(toMap(e -> mapper.apply(e.getKey()), Entry::getValue));
+	}
+	
+	@Override
+	public void writeData(Map<PolledDirectory, Set<CachedFileElement>> data) {
+		try (FileOutputStream fos = new FileOutputStream(storage.toFile());
+				ObjectOutputStream oos = new ObjectOutputStream(fos)) {
+			oos.writeObject(convertMapKey(data, dirToString));
+			oos.flush();
+		} catch (Exception e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+}

--- a/src/main/java/com/github/drapostolos/rdp4j/StatePersister.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/StatePersister.java
@@ -1,0 +1,26 @@
+package com.github.drapostolos.rdp4j;
+
+import com.github.drapostolos.rdp4j.spi.Persister;
+
+class StatePersister implements DirectoryPollerListener {
+	private final Persister persister;
+	
+	StatePersister(Persister persister) {
+		this.persister = persister;
+	}
+
+	@Override
+	public void beforeStart(BeforeStartEvent event) {
+		if(persister.containsData()) {
+			persister.readData().entrySet().forEach(entry -> {
+				event.addPolledDirectory(entry.getKey(), entry.getValue());
+			});
+		}
+	}
+
+	@Override
+	public void afterStop(AfterStopEvent event) {
+		persister.writeData(event.getCachedFileElements());
+	}
+
+}

--- a/src/main/java/com/github/drapostolos/rdp4j/Util.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/Util.java
@@ -3,10 +3,6 @@ package com.github.drapostolos.rdp4j;
 import static java.lang.Long.MAX_VALUE;
 import static java.util.concurrent.TimeUnit.DAYS;
 
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -14,8 +10,6 @@ import java.util.concurrent.FutureTask;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.github.drapostolos.rdp4j.spi.FileElement;
 
 /**
  * Utility functions for internal usage.
@@ -28,24 +22,13 @@ final class Util {
         throw new AssertionError("Not meant for instantiation");
     }
 
-    static Set<FileElement> copyValuesToFileElementSet(Map<String, CachedFileElement> files) {
-        Set<FileElement> result = new HashSet<FileElement>();
-        for (CachedFileElement file : files.values()) {
-            result.add(file.fileElement);
-        }
-        return result;
-    }
-
-    static Map<String, CachedFileElement> newLinkedHashMap() {
-        return new LinkedHashMap<String, CachedFileElement>();
-    }
-
     static void awaitTermination(ExecutorService executor) {
         while (true) {
             try {
                 executor.awaitTermination(MAX_VALUE, DAYS);
                 return;
             } catch (InterruptedException e) {
+            	Thread.currentThread().interrupt();
                 LOG.warn("Thread interrupted, but ignored.");
             }
         }

--- a/src/main/java/com/github/drapostolos/rdp4j/Util.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/Util.java
@@ -29,7 +29,8 @@ final class Util {
                 return;
             } catch (InterruptedException e) {
             	Thread.currentThread().interrupt();
-                LOG.warn("Thread interrupted, but ignored.");
+                LOG.info("Thread interrupted");
+                break;
             }
         }
     }

--- a/src/main/java/com/github/drapostolos/rdp4j/spi/FileElement.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/spi/FileElement.java
@@ -47,7 +47,10 @@ public interface FileElement {
      * @return true if this {@link FileElement} instance represents a
      *         directory, otherwise false.
      */
-    boolean isDirectory();
+    default boolean isDirectory() {
+    	return false;
+    }
+    
 
     /**
      * Returns the name of this {@link FileElement}.

--- a/src/main/java/com/github/drapostolos/rdp4j/spi/Persister.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/spi/Persister.java
@@ -4,11 +4,32 @@ import java.util.Map;
 import java.util.Set;
 
 import com.github.drapostolos.rdp4j.CachedFileElement;
+import com.github.drapostolos.rdp4j.DirectoryPoller;
 
+/**
+ * Implementations of this interface handles persisting of {@link DirectoryPoller}
+ * and {@link CachedFileElement}. Both writing/reading data from a persisting source.
+ *  
+ * @see <a href="https://github.com/drapostolos/rdp4j/wiki/User-Guide">User-Guide</a>
+ */
 public interface Persister {
-	
-	void write(Map<PolledDirectory, Set<CachedFileElement>> data);
 
-	Map<PolledDirectory, Set<CachedFileElement>> read();
+	/**
+	 * @return true if there is persisted data to read, otherwise false.
+	 */
+	boolean containsData();
 	
+	/**
+	 * Reads persisted data from a source.
+	 * 
+	 * @return the persisted data
+	 */
+	Map<PolledDirectory, Set<CachedFileElement>> readData();
+
+	/**
+	 * Persists the given <code>data</code>.
+	 * 
+	 * @param data the data to persist.
+	 */
+	void writeData(Map<PolledDirectory, Set<CachedFileElement>> data);
 }

--- a/src/main/java/com/github/drapostolos/rdp4j/spi/Persister.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/spi/Persister.java
@@ -1,0 +1,14 @@
+package com.github.drapostolos.rdp4j.spi;
+
+import java.util.Map;
+import java.util.Set;
+
+import com.github.drapostolos.rdp4j.CachedFileElement;
+
+public interface Persister {
+	
+	void write(Map<PolledDirectory, Set<CachedFileElement>> data);
+
+	Map<PolledDirectory, Set<CachedFileElement>> read();
+	
+}

--- a/src/test/java/com/github/drapostolos/rdp4j/CachedFileElementTest.java
+++ b/src/test/java/com/github/drapostolos/rdp4j/CachedFileElementTest.java
@@ -35,7 +35,7 @@ public class CachedFileElementTest {
 
     @Before
     public void testName() throws Exception {
-        cached = new CachedFileElement(fileElement, name, lastModified);
+        cached = CachedFileElement.of(fileElement);
     }
 
     @Test
@@ -49,19 +49,13 @@ public class CachedFileElementTest {
     }
 
     @Test
-    public void canHoldFileElement() throws Exception {
-        assertThat(cached.fileElement).isEqualTo(fileElement);
-    }
-
-    @Test
     public void canHoldDirectory() throws Exception {
-        isDirectory = true;
-        assertThat(cached.isDirectory()).isEqualTo(true);
+        assertThat(CachedFileElement.ofDir(name, lastModified).isDirectory()).isTrue();
     }
 
     @Test
     public void canHoldNoneDirectory() throws Exception {
-        assertThat(cached.isDirectory()).isEqualTo(false);
+        assertThat(cached.isDirectory()).isFalse();
     }
 
 }

--- a/src/test/java/com/github/drapostolos/rdp4j/DirectoryPollerBuilderTest.java
+++ b/src/test/java/com/github/drapostolos/rdp4j/DirectoryPollerBuilderTest.java
@@ -1,8 +1,12 @@
 package com.github.drapostolos.rdp4j;
 
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.github.drapostolos.rdp4j.spi.PolledDirectory;
 
 public class DirectoryPollerBuilderTest {
 
@@ -11,6 +15,18 @@ public class DirectoryPollerBuilderTest {
     @Test(expected = NullPointerException.class)
     public void nullDirectory() throws Exception {
         builder.addPolledDirectory(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void nullPreviousState() throws Exception {
+    	Set<CachedFileElement> previousState = null;
+        builder.addPolledDirectory(Mockito.mock(PolledDirectory.class), previousState);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void nullPreviousStateVarArg() throws Exception {
+    	CachedFileElement[] previousState = null;
+        builder.addPolledDirectory(Mockito.mock(PolledDirectory.class), previousState);
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/com/github/drapostolos/rdp4j/EventVerifier.java
+++ b/src/test/java/com/github/drapostolos/rdp4j/EventVerifier.java
@@ -1,6 +1,13 @@
 package com.github.drapostolos.rdp4j;
 
+import static org.mockito.Mockito.times;
+
+import java.util.AbstractMap;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import org.mockito.InOrder;
@@ -14,7 +21,7 @@ class EventVerifier {
     protected ScheduledRunnable pollerTask;
     protected AbstractRdp4jListener listenerMock;
     protected InOrder inOrder;
-    protected Set<PolledDirectory> directories = new LinkedHashSet<PolledDirectory>();
+    Map<PolledDirectory, Set<CachedFileElement>> directories = new HashMap<>();
     protected PolledDirectory directoryMock;
     protected DirectoryPoller directoryPollerMock;
 
@@ -23,32 +30,53 @@ class EventVerifier {
             pollerTask.run();
         }
     }
+    
+    private static Map.Entry<Class<?>, Integer> entry(Class<?> cls, Integer counter){
+    	return new AbstractMap.SimpleEntry<>(cls, counter);
+    }
 
     /*
      * Dispatch event to the "verifyInOrder_" methods below.
      */
     protected void verifyEventsInOrder(Class<?>... events) throws Exception {
-        for (Class<?> event : events) {
+    	LinkedList<Entry<Class<?>, Integer>> list = new LinkedList<>();
+    	
+    	for (Class<?> event : events) {
+			if(list.isEmpty()) {
+				list.addLast(entry(event, 1));
+				continue;
+			}
+			
+			Entry<Class<?>, Integer> last = list.getLast();
+			if(!last.getKey().equals(event)) {
+				list.addLast(entry(event, 1));
+				continue;
+			}
+			last.setValue(last.getValue() + 1);
+		}
+        for (Entry<Class<?>, Integer> entry : list) {
+        	Class<?> event = entry.getKey();
+        	int count = entry.getValue();
             if (event.equals(InitialContentEvent.class)) {
-                inOrder.verify(listenerMock).initialContent(Mockito.any(InitialContentEvent.class));
+                inOrder.verify(listenerMock, times(count)).initialContent(Mockito.any(InitialContentEvent.class));
             } else if (event.equals(BeforePollingCycleEvent.class)) {
-                inOrder.verify(listenerMock).beforePollingCycle(Mockito.any(BeforePollingCycleEvent.class));
+                inOrder.verify(listenerMock, times(count)).beforePollingCycle(Mockito.any(BeforePollingCycleEvent.class));
             } else if (event.equals(AfterPollingCycleEvent.class)) {
-                inOrder.verify(listenerMock).afterPollingCycle(Mockito.any(AfterPollingCycleEvent.class));
+                inOrder.verify(listenerMock, times(count)).afterPollingCycle(Mockito.any(AfterPollingCycleEvent.class));
             } else if (event.equals(FileAddedEvent.class)) {
-                inOrder.verify(listenerMock).fileAdded(Mockito.any(FileAddedEvent.class));
+                inOrder.verify(listenerMock, times(count)).fileAdded(Mockito.any(FileAddedEvent.class));
             } else if (event.equals(FileRemovedEvent.class)) {
-                inOrder.verify(listenerMock).fileRemoved(Mockito.any(FileRemovedEvent.class));
+                inOrder.verify(listenerMock, times(count)).fileRemoved(Mockito.any(FileRemovedEvent.class));
             } else if (event.equals(FileModifiedEvent.class)) {
-                inOrder.verify(listenerMock).fileModified(Mockito.any(FileModifiedEvent.class));
+                inOrder.verify(listenerMock, times(count)).fileModified(Mockito.any(FileModifiedEvent.class));
             } else if (event.equals(IoErrorCeasedEvent.class)) {
-                inOrder.verify(listenerMock).ioErrorCeased(Mockito.any(IoErrorCeasedEvent.class));
+                inOrder.verify(listenerMock, times(count)).ioErrorCeased(Mockito.any(IoErrorCeasedEvent.class));
             } else if (event.equals(IoErrorRaisedEvent.class)) {
-                inOrder.verify(listenerMock).ioErrorRaised(Mockito.any(IoErrorRaisedEvent.class));
+                inOrder.verify(listenerMock, times(count)).ioErrorRaised(Mockito.any(IoErrorRaisedEvent.class));
             } else if (event.equals(BeforeStartEvent.class)) {
-                inOrder.verify(listenerMock).beforeStart(Mockito.any(BeforeStartEvent.class));
+                inOrder.verify(listenerMock, times(count)).beforeStart(Mockito.any(BeforeStartEvent.class));
             } else if (event.equals(AfterStopEvent.class)) {
-                inOrder.verify(listenerMock).afterStop(Mockito.any(AfterStopEvent.class));
+                inOrder.verify(listenerMock, times(count)).afterStop(Mockito.any(AfterStopEvent.class));
             } else {
                 throw new RuntimeException("Missing event in When verifying order: " + event);
             }

--- a/src/test/java/com/github/drapostolos/rdp4j/EventsTest.java
+++ b/src/test/java/com/github/drapostolos/rdp4j/EventsTest.java
@@ -34,13 +34,15 @@ public class EventsTest {
         // given
         DirectoryPoller dp = Mockito.mock(DirectoryPoller.class);
         PolledDirectory directory = Mockito.mock(PolledDirectory.class);
-        FileElement file = Mockito.mock(FileElement.class);
+        FileElement fileElement = Mockito.mock(FileElement.class);
+        CachedFileElement cachedFileElement = CachedFileElement.of(fileElement);
 
         // when
-        FileAddedEvent event = new FileAddedEvent(dp, directory, file);
+        FileAddedEvent event = new FileAddedEvent(dp, directory, new FileElementAndCache(fileElement, cachedFileElement));
 
         // then
-        assertThat(event.getFileElement()).isEqualTo(file);
+        assertThat(event.getFileElement()).isEqualTo(fileElement);
+        assertThat(event.getCachedFileElement()).isEqualTo(cachedFileElement);
         assertThat(event.getPolledDirectory()).isEqualTo(directory);
         assertThat(event.getDirectoryPoller()).isEqualTo(dp);
 

--- a/src/test/java/com/github/drapostolos/rdp4j/ParallelPollerTest.java
+++ b/src/test/java/com/github/drapostolos/rdp4j/ParallelPollerTest.java
@@ -1,6 +1,6 @@
 package com.github.drapostolos.rdp4j;
 
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.concurrent.Executors;
 
 import org.junit.Test;
@@ -9,8 +9,6 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-
-import com.github.drapostolos.rdp4j.spi.PolledDirectory;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(ScheduledRunnable.class)
@@ -21,7 +19,7 @@ public class ParallelPollerTest extends EventVerifier {
         // given
         PowerMockito.mockStatic(Executors.class);
         DirectoryPoller dp = Mockito.mock(DirectoryPoller.class);
-        dp.directories = new HashSet<PolledDirectory>();
+        dp.directories = new HashMap<>();
         dp.parallelDirectoryPollingEnabled = false;
 
         // when
@@ -37,7 +35,7 @@ public class ParallelPollerTest extends EventVerifier {
         // given
         PowerMockito.mockStatic(Executors.class);
         DirectoryPoller dp = Mockito.mock(DirectoryPoller.class);
-        dp.directories = new HashSet<PolledDirectory>();
+        dp.directories = new HashMap<>();
         dp.parallelDirectoryPollingEnabled = true;
 
         // when

--- a/src/test/java/com/github/drapostolos/rdp4j/ScheduledRunnableTest.java
+++ b/src/test/java/com/github/drapostolos/rdp4j/ScheduledRunnableTest.java
@@ -28,7 +28,7 @@ public class ScheduledRunnableTest extends EventVerifier {
         inOrder = Mockito.inOrder(listenerMock);
         directoryPollerMock = Mockito.mock(DirectoryPoller.class);
         Mockito.when(directoryPollerMock.getDefaultFileFilter()).thenReturn(new DefaultFileFilter());
-        directories.add(directoryMock);
+        directories.put(directoryMock, new HashSet<>());
         directoryPollerMock.directories = directories;
         directoryPollerMock.notifier = new ListenerNotifier(new HashSet<Rdp4jListener>(Arrays.asList(listenerMock)));
         pollerTask = new ScheduledRunnable(directoryPollerMock);
@@ -302,12 +302,12 @@ public class ScheduledRunnableTest extends EventVerifier {
                 .thenReturn(list("fileA/1", "fileB/1"))
                 .thenReturn(list("fileA/1", "fileB/1"));
 
-        final List<FileElement> files = new ArrayList<FileElement>();
+        final List<FileElement> files = new ArrayList<>();
         Mockito.doAnswer(new Answer<InitialContentEvent>() {
 
             @Override
             public InitialContentEvent answer(InvocationOnMock invocation) throws Throwable {
-                Set<FileElement> s = ((InitialContentEvent) invocation.getArguments()[0]).getFiles();
+                Set<FileElement> s = ((InitialContentEvent) invocation.getArguments()[0]).getFileElements();
                 files.addAll(s);
                 return null;
             }


### PR DESCRIPTION
This PR adds: 
1.  methods to initialize a `DirectoryPoller` with a state from a previous running `DirectoryPoller`. 
2. methods to read the current state of the last poll cycle. For example this information can be persisted and used later in a new running instance of a `DirectoryPoller` in a separate JVM, by using methods in 1).

**NOTE!**
PR #27  builds upon this PR and adds a simple file persisting mechanism.


**Example for 1)**
You can initialize the `DirectoryPoller` with a previous state by adding the files known to a previous running instance of `DirectoryPoller` by calling these methods:
```java
DirectoryPoller.newBuilder()
.addPolledDirectory(new MyPolledDirectory(), CachedFileElement.of(...), CachedFileElement.ofFile(...), ...)
.addPolledDirectory(new MyPolledDirectory(), Set<CachedFileElement>)
...
.start();
```
Alternatively you can  initialize the `DirectoryPoller` with a previous state by implementing `DirectoryPollerListener.beforeStart(BeforeStartEventevent)`. Example: 
```java
@Override
public void beforeStart(BeforeStartEvent event) {
	event.addPolledDirectory(new MyPolledDirectory(), CachedFileElement.of(...), CachedFileElement.ofFile(...), ...)
	event.addPolledDirectory(new MyPolledDirectory(), Set<CachedFileElement>)
}
```

**Example for 2)**)
Implement the `DirectoryPollerListener.afterStop(AfterStopEvent event)` interface to get access to the state after last poll cycle. Example:
```java
@Override
public void afterStop(AfterStopEvent event) {
	/*
	 * cachedFileElements is a Map, where the keys are your PolledDirectories 
	 * and the values are each directory's files in the last poll cycle.
	 * This can be used to persist the data using your choice of source (file/database etc.). 
	 */
	Map<PolledDirectory, Set<CachedFileElement>> cachedFileElements = event.getCachedFileElements();
	cachedFileElements.entrySet().forEach(entry -> /* persist your data here */);
}
```
