### PR TITLE
Added simple file persisting mechanism.

### DIFF
--- a/src/main/java/com/github/drapostolos/rdp4j/SerializeToFilePersister.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/SerializeToFilePersister.java
@@ -1,0 +1,65 @@
+package com.github.drapostolos.rdp4j;
+
+import static java.util.stream.Collectors.toMap;
+
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Function;
+
+import com.github.drapostolos.rdp4j.spi.Persister;
+import com.github.drapostolos.rdp4j.spi.PolledDirectory;
+
+class SerializeToFilePersister implements Persister {
+	private Path storage;
+	private Function<String, PolledDirectory> stringToDir;
+	private Function<PolledDirectory, String> dirToString;
+
+	SerializeToFilePersister(Path file, Function<String, PolledDirectory> stringToDir,
+			Function<PolledDirectory, String> dirToString) {
+				this.storage = file;
+				this.stringToDir = stringToDir;
+				this.dirToString = dirToString;
+	}
+
+	@Override
+	public boolean containsData() {
+		return Files.exists(storage);
+	}
+
+	@Override
+	public Map<PolledDirectory, Set<CachedFileElement>> readData() {
+		try (	FileInputStream fis = new FileInputStream(storage.toFile());
+				ObjectInputStream ois = new ObjectInputStream(fis);){
+		    @SuppressWarnings("unchecked")
+			Map<String, Set<CachedFileElement>> files = (Map<String, Set<CachedFileElement>>) ois.readObject();
+		    return convertMapKey(files, stringToDir);
+		} catch (Exception e) {
+			throw new IllegalStateException(e);
+		}
+	}
+	
+	private <T, S> Map<T, Set<CachedFileElement>> convertMapKey(
+			Map<S, Set<CachedFileElement>> map, Function<S, T> mapper) {
+		return map.entrySet().stream()
+		.collect(toMap(e -> mapper.apply(e.getKey()), Entry::getValue));
+	}
+	
+	@Override
+	public void writeData(Map<PolledDirectory, Set<CachedFileElement>> data) {
+		try (FileOutputStream fos = new FileOutputStream(storage.toFile());
+				ObjectOutputStream oos = new ObjectOutputStream(fos)) {
+			oos.writeObject(convertMapKey(data, dirToString));
+			oos.flush();
+		} catch (Exception e) {
+			throw new IllegalStateException(e);
+		}
+	}
+
+}

--- a/src/main/java/com/github/drapostolos/rdp4j/StatePersister.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/StatePersister.java
@@ -1,0 +1,26 @@
+package com.github.drapostolos.rdp4j;
+
+import com.github.drapostolos.rdp4j.spi.Persister;
+
+class StatePersister implements DirectoryPollerListener {
+	private final Persister persister;
+	
+	StatePersister(Persister persister) {
+		this.persister = persister;
+	}
+
+	@Override
+	public void beforeStart(BeforeStartEvent event) {
+		if(persister.containsData()) {
+			persister.readData().entrySet().forEach(entry -> {
+				event.addPolledDirectory(entry.getKey(), entry.getValue());
+			});
+		}
+	}
+
+	@Override
+	public void afterStop(AfterStopEvent event) {
+		persister.writeData(event.getCachedFileElements());
+	}
+
+}

--- a/src/main/java/com/github/drapostolos/rdp4j/Util.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/Util.java
@@ -29,7 +29,8 @@ final class Util {
                 return;
             } catch (InterruptedException e) {
             	Thread.currentThread().interrupt();
-                LOG.warn("Thread interrupted, but ignored.");
+                LOG.info("Thread interrupted");
+                break;
             }
         }
     }

--- a/src/main/java/com/github/drapostolos/rdp4j/spi/Persister.java
+++ b/src/main/java/com/github/drapostolos/rdp4j/spi/Persister.java
@@ -4,11 +4,32 @@ import java.util.Map;
 import java.util.Set;
 
 import com.github.drapostolos.rdp4j.CachedFileElement;
+import com.github.drapostolos.rdp4j.DirectoryPoller;
 
+/**
+ * Implementations of this interface handles persisting of {@link DirectoryPoller}
+ * and {@link CachedFileElement}. Both writing/reading data from a persisting source.
+ *  
+ * @see <a href="https://github.com/drapostolos/rdp4j/wiki/User-Guide">User-Guide</a>
+ */
 public interface Persister {
-	
-	void write(Map<PolledDirectory, Set<CachedFileElement>> data);
 
-	Map<PolledDirectory, Set<CachedFileElement>> read();
+	/**
+	 * @return true if there is persisted data to read, otherwise false.
+	 */
+	boolean containsData();
 	
+	/**
+	 * Reads persisted data from a source.
+	 * 
+	 * @return the persisted data
+	 */
+	Map<PolledDirectory, Set<CachedFileElement>> readData();
+
+	/**
+	 * Persists the given <code>data</code>.
+	 * 
+	 * @param data the data to persist.
+	 */
+	void writeData(Map<PolledDirectory, Set<CachedFileElement>> data);
 }


### PR DESCRIPTION
Added a default persisting mechanism, that can persist the state of each `PolledDirectory` to file, which can later be used by another instance of the `DirectoryPoller`.

Usage Example:
```java

Path storage = Paths.get("folder", "file.dat");
DirectoryPoller.newBuilder()
.addPolledDirectory(new JavaIoFileAdapter(new File("C:\\temp\\polled1")))
.enableDefaultStatePersisting(storage, 
	dir -> ((JavaIoFileAdapter)dir).getFile().toString(), 
	str -> new JavaIoFileAdapter(new File(str)))
.addListener(new AbstractRdp4jListener() {
	@Override
	public void fileAdded(FileAddedEvent event) throws InterruptedException {
		System.out.println("+" + event.getFileElement());
	}
	@Override
	public void fileRemoved(FileRemovedEvent event) throws InterruptedException {
		System.out.println("-" + event.getFileElement());
	}
	@Override
	public void fileModified(FileModifiedEvent event) throws InterruptedException {
		System.out.println("@" + event.getFileElement());
	}
})
.start()
.awaitTermination();
``` 